### PR TITLE
Create Dockerfile

### DIFF
--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -8,7 +8,9 @@
 # Used for build environments, not for deployment.
 # This includes the rust compiler, which probably isn't needed
 # in a production environment.
-FROM rust:1.64 as builder
+# Need to pull from the buster tag since the production environment
+# also uses buster.  If not, glibc errors appear at runtime.
+FROM rust:1.64-buster as builder
 WORKDIR /usr/src/ritlug
 
 # Copy only the things needed to compile into

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -5,6 +5,8 @@
 # run the following shell command:
 # docker build -f deployments/docker/Dockerfile -t ritlug-discord-bot .
 
+######## Build Environment ########
+
 # Used for build environments, not for deployment.
 # This includes the rust compiler, which probably isn't needed
 # in a production environment.
@@ -20,6 +22,8 @@ WORKDIR /usr/src/ritlug
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./src ./src
 RUN cargo install --path .
+
+######## Production Environment ########
 
 # Using Debian's slimmed-down version of buster since we need
 # to install additional dependencies, and that's easiest to do in a distro

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile inspired from: https://hub.docker.com/_/rust/
+
+# How to run:
+# With the working directory set to the root of this repository,
+# run the following shell command:
+# docker build -f deployments/docker/Dockerfile -t ritlug-discord-bot .
+
+# Used for build environments, not for deployment.
+# This includes the rust compiler, which probably isn't needed
+# in a production environment.
+FROM rust:1.64 as builder
+WORKDIR /usr/src/ritlug
+
+# Copy only the things needed to compile into
+# the build environment, otherwise each time a file changes
+# anywhere else in the repo, we'll have to recompile even if no
+# source files change.
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./src ./src
+RUN cargo install --path .
+
+# Using Debian's slimmed-down version of buster since we need
+# to install additional dependencies, and that's easiest to do in a distro
+# with a package manager.
+FROM debian:buster-slim
+
+# Need openSSL for the bot to run, so install that.
+RUN apt-get update && \
+    apt-get install -y openssl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/ritlug /usr/local/bin/ritlug
+
+CMD ["/usr/local/bin/ritlug"]


### PR DESCRIPTION
Created a Dockerfile that allows one to build and run the bot.

To build the Docker image, run ```docker build -f deployments/docker/Dockerfile -t ritlug-discord-bot .``` in the root of the repository.

To run the docker image, run ```docker run --rm -it ritlug-discord-bot```.  This will result in an error message from the bot if no environment variables are configured... but it does run.

```
docker run --rm -it ritlug-discord-bot
thread 'main' panicked at 'Could not find BOT_TOKEN in environment variables: NotPresent', src/main.rs:101:44
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

To be somewhat consistent with RITlug's Teleirc project, I put the Docker file inside of a deployments folder in the root of the repo, but it can be put wherever make sense.