### PR TITLE
Add /help command

### DIFF
--- a/src/commands/bridge.rs
+++ b/src/commands/bridge.rs
@@ -1,3 +1,7 @@
+/// Show information about where this channel is bridged to.
+/// 
+/// "Bridging" a channel to somewhere else means that any messages sent within
+/// the channel are automatically sent to that place, and vice versa.
 #[poise::command(slash_command)]
 pub async fn bridge(ctx: crate::Context<'_>) -> Result<(), crate::Error> {
     let dc_channel = ctx.channel_id();

--- a/src/commands/copypasta.rs
+++ b/src/commands/copypasta.rs
@@ -1,3 +1,4 @@
+/// I'd just like to interject for a moment...
 #[poise::command(slash_command)]
 pub async fn linux(ctx: crate::Context<'_>) -> Result<(), crate::Error> {
   let text = concat!(
@@ -18,6 +19,7 @@ pub async fn linux(ctx: crate::Context<'_>) -> Result<(), crate::Error> {
   Ok(())
 }
 
+/// I use Alpine!
 #[poise::command(slash_command)]
 pub async fn linuxresponse(ctx: crate::Context<'_>) -> Result<(), crate::Error> {
   let text = concat!(

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,0 +1,95 @@
+use crate::{Error, Context};
+
+/// Show a list of commands or information about a specific command.
+/// 
+/// Use `/help` without an argument to show a list of commands with short 
+/// descriptions for each. Use `/help <command>` to show more detailed 
+/// information about a specific command.
+#[poise::command(slash_command)]
+pub async fn help(
+    ctx: Context<'_>,
+    command: Option<String>,
+) -> Result<(), Error> {
+
+    match command {
+        Some(cmd) => help_command(ctx, cmd).await?,
+        None => help_general(ctx).await?
+    }
+
+    Ok(())
+}
+
+async fn help_general(ctx: Context<'_>) -> Result<(), Error> {
+    let commands = ctx.framework().options.commands
+        .iter()
+        .filter(|c| !c.hide_in_help);
+    
+    let mut body = "Use `/help <command>` to view more detailed help information.\n\n".to_owned();
+    for cmd in commands {
+        body += "**`/";
+        body += &cmd.name;
+        body += "`**";
+        if let Some(desc) = cmd.description.as_ref() {
+            body += " - ";
+            body += desc;
+        }
+        body.push('\n');
+    }
+    
+    ctx.send(|b|
+        b.embed(|e| {
+            e.title("RITlug Bot Help");
+            e.description(body);
+            e
+        }).ephemeral(true)
+    ).await?;
+
+    Ok(())
+}
+
+async fn help_command(ctx: Context<'_>, command: String) -> Result<(), Error> {
+    let cmd = ctx.framework().options.commands.iter().find(|item| !item.hide_in_help && item.name == command);
+
+    if let Some(cmd) = cmd {
+        let mut body = cmd.description.clone().unwrap_or_else(|| String::new());
+        if let Some(help) = cmd.help_text {
+            body += "\n\n";
+            body += &help();
+        }
+
+        let mut fields = vec![];
+
+        let subcommands: Vec<_> = cmd.subcommands.iter().filter(|c| !c.hide_in_help).collect();
+        if subcommands.len() != 0 {
+            let mut text = String::new();
+            for subcmd in subcommands {
+                text += "**`/";
+                text += &subcmd.name;
+                text += "`**";
+                if let Some(desc) = subcmd.description.as_ref() {
+                    text += " - ";
+                    text += desc;
+                }
+                text.push('\n');
+            }
+            fields.push(("Subcommands", text, false));
+        }
+        
+        ctx.send(|b| 
+            b.embed(|e| {
+                e.title(format!("Help for command `/{}`", command));
+                e.description(body);
+                e.fields(fields);
+                e
+            }).ephemeral(true)
+        ).await?;
+    } else {
+        ctx.send(|b| 
+            b.content(
+                format!("No command with the name `/{}`. Use `/help` for a list of commands.", command)
+            ).ephemeral(true)
+        ).await?;
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,6 @@
+mod help;
+pub use help::help;
+
 mod ping;
 pub use ping::ping;
 

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,5 +1,6 @@
 use crate::{Context, Error};
 
+/// Pong!
 #[poise::command(slash_command)]
 pub async fn ping(ctx: Context<'_>) -> Result<(), Error> {
     ctx.say("Pong!").await?;

--- a/src/commands/roles.rs
+++ b/src/commands/roles.rs
@@ -8,6 +8,10 @@ use crate::{Context, Error};
 use crate::database;
 use crate::util;
 
+/// Add a role to the role menu.
+/// 
+/// The first argument is the role to add, the second is the page number.
+/// Use `/deleterole` to remove a role.
 #[poise::command(slash_command, required_permissions = "MANAGE_ROLES")]
 pub async fn addrole(
     ctx: Context<'_>,
@@ -49,6 +53,9 @@ pub async fn addrole(
     Ok(())
 }
 
+/// Delete a role from the role menu.
+/// 
+/// The first argument is the role to delete, the second is the page number.
 #[poise::command(slash_command, required_permissions = "MANAGE_ROLES")]
 pub async fn deleterole(
     ctx: Context<'_>,
@@ -90,6 +97,10 @@ pub async fn deleterole(
     Ok(())
 }
 
+/// Add a page to the role menu.
+/// 
+/// The first argument is the page's title, the second is the page's
+/// description. Use `/deleterolepage` to delete a page.
 #[poise::command(slash_command, required_permissions = "MANAGE_ROLES")]
 pub async fn addrolepage(
     ctx: Context<'_>,
@@ -107,6 +118,9 @@ pub async fn addrolepage(
   Ok(())
 }
 
+/// Delete a page from the role menu.
+/// 
+/// The first and only argument is the page number to delete.
 #[poise::command(slash_command, required_permissions = "MANAGE_ROLES")]
 pub async fn deleterolepage(
     ctx: Context<'_>,
@@ -127,6 +141,12 @@ pub async fn deleterolepage(
   Ok(())
 }
 
+/// Open the role menu.
+/// 
+/// Use this menu to assign yourself roles. Use the Previous
+/// and Next buttons to select a page, and then use the
+/// dropdown menu to choose a role to toggle. Once you are
+/// done, you can press Exit to close the menu.
 #[poise::command(slash_command)]
 pub async fn roles(
     ctx: Context<'_>

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -25,6 +25,7 @@ lazy_static! {
     };
 }
 
+/// Verify yourself using your email address.
 #[poise::command(slash_command, subcommands("request", "confirm", "purge"))]
 pub async fn verify(
     _ctx: Context<'_>,
@@ -32,6 +33,7 @@ pub async fn verify(
     Ok(())
 }
 
+/// Request to be verified. Specify the email you want to use as an argument.
 #[poise::command(slash_command)]
 pub async fn request(
     ctx: Context<'_>,
@@ -131,6 +133,7 @@ pub async fn request(
     Ok(())
 }
 
+/// Confirm your verification by providing the PIN sent to your email.
 #[poise::command(slash_command)]
 pub async fn confirm(
     ctx: Context<'_>,
@@ -199,6 +202,7 @@ pub async fn confirm(
     Ok(())
 }
 
+/// Purge verified users
 #[poise::command(slash_command, subcommands("email", "user"))]
 pub async fn purge(
     _ctx: Context<'_>

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ pub async fn event_listener(
     Ok(())
 }
 
-#[poise::command(prefix_command)]
+#[poise::command(prefix_command, hide_in_help)]
 async fn register(ctx: Context<'_>) -> Result<(), Error> {
     poise::builtins::register_application_commands_buttons(ctx).await?;
     Ok(())
@@ -173,6 +173,7 @@ async fn main() {
         .options(poise::FrameworkOptions {
             commands: vec![
                 register(),
+                commands::help(),
                 commands::ping(),
                 commands::addrole(),
                 commands::deleterole(),
@@ -182,7 +183,7 @@ async fn main() {
                 commands::verify(),
                 commands::bridge(),
                 commands::linux(),
-                commands::linuxresponse()
+                commands::linuxresponse(),
             ],
             listener: |ctx, event, framework, user_data| {
                 Box::pin(event_listener(


### PR DESCRIPTION
 - Add the command `/help`, which either displays a list of commands with short descriptions or a long description for a specific command
 - Add help text to each command (in the form of doc comments)